### PR TITLE
Fix for fresh build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ controller:
     entrypoint: /bin/bash
     command: -c "make build && cd controller && ./controller -D server --rethinkdb-addr rethinkdb:28015"
     volumes:
-      - "$PWD:/usr/src/app"
+      - ".:/usr/src/app"
       - "/var/run/docker.sock:/var/run/docker.sock"
     links:
         - rethinkdb


### PR DESCRIPTION
My first pull request. I dont know if I am doing right. Simple fix for fresh builds in Mac osx.
[Question] I am not running linux at the host. So can I make docker-compose.ui.yml start in a container inside a VM (maybe the same that is running the controller and rethink-db with different ports)? 